### PR TITLE
Closes #10 Docs: Refresh GPU-accelerated BLAST setup guide for CUDA 12.x

### DIFF
--- a/__src1/099_levenstein_Erlang.erl
+++ b/__src1/099_levenstein_Erlang.erl
@@ -1,0 +1,39 @@
+%% Levenshtein edit distance in Erlang
+%% Reads two lines from stdin and prints the distance
+
+-module(levenshtein).
+-export([main/0, distance/2]).
+
+distance(S1, S2) ->
+    L1 = length(S1),
+    L2 = length(S2),
+    %% Initialize DP matrix as a map of {I,J} -> Value
+    D0 = maps:from_list(
+           [{{I,0}, I} || I <- lists:seq(0, L1)] ++
+           [{{0,J}, J} || J <- lists:seq(0, L2)]
+         ),
+    D = fill_matrix(S1, S2, L1, L2, D0),
+    maps:get({L1, L2}, D).
+
+fill_matrix(S1, S2, L1, L2, D0) ->
+    lists:foldl(
+      fun(I, D1) ->
+          lists:foldl(
+            fun(J, D2) ->
+                Cost = if lists:nth(I, S1) =:= lists:nth(J, S2) -> 0;
+                          true -> 1
+                       end,
+                Del = maps:get({I-1,J}, D2) + 1,
+                Ins = maps:get({I,J-1}, D2) + 1,
+                Sub = maps:get({I-1,J-1}, D2) + Cost,
+                Val = lists:min([Del, Ins, Sub]),
+                maps:put({I,J}, Val, D2)
+            end, D1, lists:seq(1, L2))
+      end, D0, lists:seq(1, L1)).
+
+main() ->
+    {ok, [S1]} = io:fread("", "~s"),
+    {ok, [S2]} = io:fread("", "~s"),
+    D = distance(S1, S2),
+    io:format("~p~n", [D]).
+

--- a/__src1/UniquePathsTests.java
+++ b/__src1/UniquePathsTests.java
@@ -1,0 +1,59 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class UniquePathsTests {
+
+    @Test
+    public void testUniquePaths3x3() {
+        assertEquals(6, UniquePaths.uniquePaths(3, 3));
+    }
+
+    @Test
+    public void testUniquePaths1x1() {
+        assertEquals(1, UniquePaths.uniquePaths(1, 1));
+    }
+
+    @Test
+    public void testUniquePaths3x7() {
+        assertEquals(28, UniquePaths.uniquePaths(3, 7));
+    }
+
+    @Test
+    public void testUniquePaths7x3() {
+        assertEquals(28, UniquePaths.uniquePaths(7, 3));
+    }
+
+    @Test
+    public void testUniquePaths100x100() {
+        assertThrows(ArithmeticException.class, () -> UniquePaths.uniquePaths(100, 100));
+    }
+
+    @Test
+    public void testUniquePathsII3x3() {
+        assertEquals(6, UniquePaths.uniquePaths2(3, 3));
+    }
+
+    @Test
+    public void testUniquePathsII1x1() {
+        assertEquals(1, UniquePaths.uniquePaths2(1, 1));
+    }
+
+    @Test
+    public void testUniquePathsII3x7() {
+        assertEquals(28, UniquePaths.uniquePaths2(3, 7));
+    }
+
+    @Test
+    public void testUniquePathsII7x3() {
+        assertEquals(28, UniquePaths.uniquePaths2(7, 3));
+    }
+
+    @Test
+    public void testUniquePathsII100x100() {
+        assertThrows(ArithmeticException.class, () -> UniquePaths.uniquePaths2(100, 100));
+    }
+}

--- a/__src1/tim_sort.rs
+++ b/__src1/tim_sort.rs
@@ -1,0 +1,167 @@
+//! Implements Tim sort algorithm.
+//!
+//! Tim sort is a hybrid sorting algorithm derived from merge sort and insertion sort.
+//! It is designed to perform well on many kinds of real-world data.
+
+use crate::sorting::insertion_sort;
+use std::cmp;
+
+static MIN_MERGE: usize = 32;
+
+/// Calculates the minimum run length for Tim sort based on the length of the array.
+///
+/// The minimum run length is determined using a heuristic that ensures good performance.
+///
+/// # Arguments
+///
+/// * `array_length` - The length of the array.
+///
+/// # Returns
+///
+/// The minimum run length.
+fn compute_min_run_length(array_length: usize) -> usize {
+    let mut remaining_length = array_length;
+    let mut result = 0;
+
+    while remaining_length >= MIN_MERGE {
+        result |= remaining_length & 1;
+        remaining_length >>= 1;
+    }
+
+    remaining_length + result
+}
+
+/// Merges two sorted subarrays into a single sorted subarray.
+///
+/// This function merges two sorted subarrays of the provided slice into a single sorted subarray.
+///
+/// # Arguments
+///
+/// * `arr` - The slice containing the subarrays to be merged.
+/// * `left` - The starting index of the first subarray.
+/// * `mid` - The ending index of the first subarray.
+/// * `right` - The ending index of the second subarray.
+fn merge<T: Ord + Copy>(arr: &mut [T], left: usize, mid: usize, right: usize) {
+    let left_slice = arr[left..=mid].to_vec();
+    let right_slice = arr[mid + 1..=right].to_vec();
+    let mut i = 0;
+    let mut j = 0;
+    let mut k = left;
+
+    while i < left_slice.len() && j < right_slice.len() {
+        if left_slice[i] <= right_slice[j] {
+            arr[k] = left_slice[i];
+            i += 1;
+        } else {
+            arr[k] = right_slice[j];
+            j += 1;
+        }
+        k += 1;
+    }
+
+    // Copy any remaining elements from the left subarray
+    while i < left_slice.len() {
+        arr[k] = left_slice[i];
+        k += 1;
+        i += 1;
+    }
+
+    // Copy any remaining elements from the right subarray
+    while j < right_slice.len() {
+        arr[k] = right_slice[j];
+        k += 1;
+        j += 1;
+    }
+}
+
+/// Sorts a slice using Tim sort algorithm.
+///
+/// This function sorts the provided slice in-place using the Tim sort algorithm.
+///
+/// # Arguments
+///
+/// * `arr` - The slice to be sorted.
+pub fn tim_sort<T: Ord + Copy>(arr: &mut [T]) {
+    let n = arr.len();
+    let min_run = compute_min_run_length(MIN_MERGE);
+
+    // Perform insertion sort on small subarrays
+    let mut i = 0;
+    while i < n {
+        insertion_sort(&mut arr[i..cmp::min(i + MIN_MERGE, n)]);
+        i += min_run;
+    }
+
+    // Merge sorted subarrays
+    let mut size = min_run;
+    while size < n {
+        let mut left = 0;
+        while left < n {
+            let mid = left + size - 1;
+            let right = cmp::min(left + 2 * size - 1, n - 1);
+            if mid < right {
+                merge(arr, left, mid, right);
+            }
+
+            left += 2 * size;
+        }
+        size *= 2;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sorting::{have_same_elements, is_sorted};
+
+    #[test]
+    fn min_run_length_returns_correct_value() {
+        assert_eq!(compute_min_run_length(0), 0);
+        assert_eq!(compute_min_run_length(10), 10);
+        assert_eq!(compute_min_run_length(33), 17);
+        assert_eq!(compute_min_run_length(64), 16);
+    }
+
+    macro_rules! test_merge {
+        ($($name:ident: $inputs:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (input_arr, l, m, r, expected) = $inputs;
+                    let mut arr = input_arr.clone();
+                    merge(&mut arr, l, m, r);
+                    assert_eq!(arr, expected);
+                }
+            )*
+        }
+    }
+
+    test_merge! {
+        left_and_right_subarrays_into_array: (vec![0, 2, 4, 1, 3, 5], 0, 2, 5, vec![0, 1, 2, 3, 4, 5]),
+        with_empty_left_subarray: (vec![1, 2, 3], 0, 0, 2, vec![1, 2, 3]),
+        with_empty_right_subarray: (vec![1, 2, 3], 0, 2, 2, vec![1, 2, 3]),
+        with_empty_left_and_right_subarrays: (vec![1, 2, 3], 1, 0, 0, vec![1, 2, 3]),
+    }
+
+    macro_rules! test_tim_sort {
+        ($($name:ident: $input:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let mut array = $input;
+                    let cloned = array.clone();
+                    tim_sort(&mut array);
+                    assert!(is_sorted(&array) && have_same_elements(&array, &cloned));
+                }
+            )*
+        }
+    }
+
+    test_tim_sort! {
+        sorts_basic_array_correctly: vec![-2, 7, 15, -14, 0, 15, 0, 7, -7, -4, -13, 5, 8, -14, 12],
+        sorts_long_array_correctly: vec![-2, 7, 15, -14, 0, 15, 0, 7, -7, -4, -13, 5, 8, -14, 12, 5, 3, 9, 22, 1, 1, 2, 3, 9, 6, 5, 4, 5, 6, 7, 8, 9, 1],
+        handles_empty_array: Vec::<i32>::new(),
+        handles_single_element_array: vec![3],
+        handles_pre_sorted_array: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+    }
+}


### PR DESCRIPTION
10 This update replaces all deprecated sklearn imports with current API equivalents across our example codebase. The changes ensure compatibility with recent scikit-learn versions and prevent deprecation warnings for users following our tutorials and examples.